### PR TITLE
fix: remove input `tagName` 

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,10 +3,6 @@ description: 'Create a release on tag push'
 author: 'lvjiaxuan <471501748@qq.com> (https://github.com/lvjiaxuan)'
 # https://docs.github.com/en/rest/releases/releases#create-a-release
 inputs:
-  tag_name:
-    description: 'The name of the tag. Use `@action/github.context.ref` if not provided'
-    required: false
-    default: ''
   name:
     description: 'The name of the release.'
     required: false

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ async function run(): Promise<void> {
 
     // Get inputs
     // https://docs.github.com/en/rest/releases/releases#create-a-release
-    const tagName = core.getInput('tag_name', { required: false }) || github.context.ref.replace('refs/tags/', '')
+    const tagName = github.context.ref.replace('refs/tags/', '')
     const name = core.getInput('name', { required: false })
     const body = core.getInput('body', { required: false })
     const draft = core.getBooleanInput('draft', { required: false })


### PR DESCRIPTION
There is no need to input a `tagName` separately, because the trigger condition of the workflow has one.